### PR TITLE
Add Partial type to customizeRetry

### DIFF
--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -57,7 +57,7 @@ export function customizeDecorator<T>(customConfig: Partial<RetryConfig<T>>): ty
 }
 
 // tslint:disable-next-line
-export function customizeRetry<T>(customConfig: Partial<RetryConfig<T>>): (f: () => Promise<T>, config?: RetryConfig<T>) => Promise<T> {
+export function customizeRetry<T>(customConfig: Partial<RetryConfig<T>>): (f: () => Promise<T>, config?: Partial<RetryConfig<T>>) => Promise<T> {
     return (f, c) => {
         const customized = Object.assign({}, customConfig, c);
         return retry(f, customized);

--- a/test/retry-promise.test.ts
+++ b/test/retry-promise.test.ts
@@ -76,6 +76,12 @@ describe("Retry Promise", () => {
         await expect(shortRetry(async () => wait(10))).to.be.rejectedWith("Timeout");
     });
 
+    it("customized retry should return customizable retry", async () => {
+        const customRetry = customizeRetry({timeout: 5});
+
+        await customRetry(async () => wait(1), {delay: 1});
+    });
+
     it("can customize default config", async () => {
         const originalTimeout = defaultRetryConfig.timeout;
         try {


### PR DESCRIPTION
I ran into the issue of not being able to partially provide a config for a customizedRetry, this should fix it