### PR TITLE
Use default type for "until" function in "RetryConfig"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export interface RetryConfig<T> {
     // maximal backoff in ms (default: 5 * 60 * 1000)
     maxBackOff?: number;
 
-    // allows to abort retrying for certain errors (default: () => true)
+    // allows to abort retrying for certain errors, will retry until false (default: () => true)
     retryIf: (error: any) => boolean
 }
 ```

--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -2,12 +2,15 @@
 
 import {timeout} from "./timeout";
 
-export interface BasicRetryConfig {
+export interface RetryConfig<T = any> {
     // number of maximal retry attempts (default: 10)
     retries: number | "INFINITELY";
 
     // wait time between retries in ms (default: 100)
     delay: number;
+
+    // check the result, will retry until true (default: () => true)
+    until: (t: T) => boolean;
 
     // log events (default: () => undefined)
     logger: (msg: string) => void;
@@ -23,11 +26,6 @@ export interface BasicRetryConfig {
 
     // allows to abort retrying for certain errors
     retryIf: (error: any) => boolean
-}
-
-export interface RetryConfig<T = void> extends BasicRetryConfig {
-    // check the result, will retry until true (default: () => true)
-    until: (t: T) => boolean;
 }
 
 const fixedBackoff = (attempt: number, delay: number) => delay;

--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -2,7 +2,7 @@
 
 import {timeout} from "./timeout";
 
-export interface RetryConfig<T> {
+export interface RetryConfig<T = void> {
     // number of maximal retry attempts (default: 10)
     retries: number | "INFINITELY";
 

--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -2,15 +2,12 @@
 
 import {timeout} from "./timeout";
 
-export interface RetryConfig<T = void> {
+export interface BasicRetryConfig {
     // number of maximal retry attempts (default: 10)
     retries: number | "INFINITELY";
 
     // wait time between retries in ms (default: 100)
     delay: number;
-
-    // check the result, will retry until true (default: () => true)
-    until: (t: T) => boolean;
 
     // log events (default: () => undefined)
     logger: (msg: string) => void;
@@ -26,6 +23,11 @@ export interface RetryConfig<T = void> {
 
     // allows to abort retrying for certain errors
     retryIf: (error: any) => boolean
+}
+
+export interface RetryConfig<T = void> extends BasicRetryConfig {
+    // check the result, will retry until true (default: () => true)
+    until: (t: T) => boolean;
 }
 
 const fixedBackoff = (attempt: number, delay: number) => delay;


### PR DESCRIPTION
Hello @normartin, I came across your library today and I like it a lot. 👍 I am also importing the typings of `RetryConfig` to have a type-safe config. I noticed, that I have to supply a type argument for the `RetryConfig` even when I am not making use of the `until` functionality:

```ts
import {RetryConfig} from 'ts-retry-promise';

const retryConfig: Partial<RetryConfig<any>> = {
  retries: 'INFINITELY',
  delay: 1_000,
  retryIf: (error: unknown) => {
    if (hasErrorCode(error) && error.code === 'OFFLINE') {
      return true;
    }
    return false;
  }
};
```

As the `until` functionality is the only config that would need this parameter, I think my use case will apply to everyone who wants to reuse the `RetryConfig` type but doesn't need `until`. 

I suggest giving it a default type argument of `any`, so that only developers who need it, need to configure it. What do you think?