### PR TITLE
Fix errors not having a message property

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Wrapped function can throw `NotRetryableError` if retrying need to be stopped ev
 ```typescript
 import { NotRetryableError } from 'ts-retry-promise';
 
-retry(async () => throw new NotRetryableError("This error"))
-    .catch(err => console.log(err.lastError), { retries: 'INFINITELY' });
+retry(async () => { throw new NotRetryableError("This error") }, { retries: 'INFINITELY' })
+    .catch(err => console.log(err.lastError.message));  // will print "This error"
 ```
 
 ## Samples ##

--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -140,9 +140,9 @@ export class RetryError extends Error {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-class BaseError extends Error{
-    constructor (message?: string) {
-        super(message);
+class BaseError {
+    constructor (public message?: string, ...args: unknown[]) {
+        Error.apply(this, args as any);
     }
 }
 

--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -140,9 +140,9 @@ export class RetryError extends Error {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-class BaseError {
-    constructor (...args: unknown[]) {
-        Error.apply(this, args as any);
+class BaseError extends Error{
+    constructor (message?: string) {
+        super(message);
     }
 }
 

--- a/test/notretryable.error.test.ts
+++ b/test/notretryable.error.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "./index";
-import {retry, NotRetryableError} from "../src/retry-promise";
+import {retry, NotRetryableError, RetryError} from "../src/retry-promise";
 
 describe("NotRetryableError Error", () => {
 
@@ -9,6 +9,20 @@ describe("NotRetryableError Error", () => {
 
     expect(result).to.be.rejected;
     expect(failer.calls).to.eq(1);
+  });
+
+  it("should have RetryError in lastError", async () => {
+    const error = new NotRetryableError("stop retrying");
+
+    const result = retry(async () => {throw error});
+
+    expect(result).to.be.eventually.rejected.with.property("lastError").eq(error);
+  });
+
+  it("RetryError should have message", async () => {
+      const error = new NotRetryableError("stop retrying");
+
+      expect(error.message).to.eq("stop retrying");
   });
 
 });

--- a/test/notretryable.error.test.ts
+++ b/test/notretryable.error.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "./index";
-import {retry, NotRetryableError, RetryError} from "../src/retry-promise";
+import {retry, NotRetryableError} from "../src/retry-promise";
 
 describe("NotRetryableError Error", () => {
 

--- a/test/retry-promise.demo.test.ts
+++ b/test/retry-promise.demo.test.ts
@@ -100,7 +100,7 @@ describe("Retry Promise Demo", () => {
     it("NotRetryableError demo", async () => {
 
         const result = retry(
-            async () => {throw new NotRetryableError("This error");},
+            async () => { throw new NotRetryableError("This error"); },
             { retries: 'INFINITELY' })
             // tslint:disable-next-line:no-console
             .catch(err => console.log(err.lastError.message));  // will print "This error"

--- a/test/retry-promise.demo.test.ts
+++ b/test/retry-promise.demo.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "./index";
-import {customizeRetry, defaultRetryConfig, retry, retryDecorator, wait} from "../src/retry-promise";
+import {customizeRetry, defaultRetryConfig, NotRetryableError, retry, retryDecorator, wait} from "../src/retry-promise";
 
 describe("Retry Promise Demo", () => {
 
@@ -95,6 +95,17 @@ describe("Retry Promise Demo", () => {
         const profile = await robustProfileLoader(123);
 
         expect(profile.name).to.eq("Mr 123");
+    })
+
+    it("NotRetryableError demo", async () => {
+
+        const result = retry(
+            async () => {throw new NotRetryableError("This error");},
+            { retries: 'INFINITELY' })
+            // tslint:disable-next-line:no-console
+            .catch(err => console.log(err.lastError.message));  // will print "This error"
+
+        await result;
     })
 
 });


### PR DESCRIPTION
Both `RetryError` and `NotRetryableError` now have a `message` property. Change should be backward compatible as it only adds an optional property.