### PR TITLE
use tsdoc comments for hover/completion hints

### DIFF
--- a/src/retry-promise.ts
+++ b/src/retry-promise.ts
@@ -3,28 +3,51 @@
 import {timeout} from "./timeout";
 
 export interface RetryConfig<T = any> {
-    // number of maximal retry attempts (default: 10)
+    /**
+     * number of maximal retry attempts
+     * @defaultValue 10
+     */
     retries: number | "INFINITELY";
 
-    // wait time between retries in ms (default: 100)
+    /**
+     * wait time between retries in ms
+     * @defaultValue 100
+     */
     delay: number;
 
-    // check the result, will retry until true (default: () => true)
+    /**
+     * check the result, will retry until true
+     * @defaultValue () => true
+     */
     until: (t: T) => boolean;
 
-    // log events (default: () => undefined)
+    /**
+     * log events
+     * @defaultValue () => undefined
+     */
     logger: (msg: string) => void;
 
-    // overall timeout in ms (default: 60 * 1000)
+    /**
+     * overall timeout in ms
+     * @defaultValue 60 * 1000
+     */
     timeout: number | "INFINITELY";
 
-    // increase delay with every retry (default: "FIXED")
+    /**
+     * increase delay with every retry
+     * @defaultValue "FIXED"
+     */
     backoff: "FIXED" | "EXPONENTIAL" | "LINEAR" | ((attempt: number, delay: number) => number);
 
-    // maximal backoff in ms (default: 5 * 60 * 1000)
+    /**
+     * maximal backoff in ms
+     * @defaultValue 5 * 60 * 1000
+     */
     maxBackOff: number;
 
-    // allows to abort retrying for certain errors
+    /**
+     * allows to abort retrying for certain errors
+     */
     retryIf: (error: any) => boolean
 }
 


### PR DESCRIPTION
Hi and thank you for your project. I updated the format of the comments for the retry config interface due to typescript only picks them and displays in hover/completion hints when a block comments are used. I also updated the default value tag to use tsdoc one. 

Demo:
![Screenshot 2024-03-22 at 11 03 18](https://github.com/normartin/ts-retry-promise/assets/5817809/7e9f6486-f021-41b2-a712-73c23e2720be)


hope this helps