### PR TITLE
Fix source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE.txt"
+    "LICENSE.txt",
+    "src"
   ],
   "main": "dist/retry-promise.js",
   "types": "dist/retry-promise.d.ts",


### PR DESCRIPTION
Add `src/` dir to package, which is referenced `retry-promise.js.map`